### PR TITLE
Improve logs

### DIFF
--- a/pkg/controller/multinetwork_controller.go
+++ b/pkg/controller/multinetwork_controller.go
@@ -38,7 +38,7 @@ type MultiNetworkReconciler struct {
 
 // Reconcile handles the reconciliation of MultiNetworkPolicy resources
 func (m *MultiNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithValues("namespace", req.NamespacedName.Namespace, "name", req.NamespacedName.Name)
+	logger := log.FromContext(ctx)
 
 	logger.Info("Starting reconciliation of MultiNetworkPolicy")
 
@@ -291,6 +291,13 @@ func (m *MultiNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multiv1beta1.MultiNetworkPolicy{}).
 		WithEventFilter(MultiNetworkPolicyPredicate).
+		WithLogConstructor(func(req *ctrl.Request) logr.Logger {
+			log := mgr.GetLogger()
+			if req != nil {
+				log = log.WithValues("namespace", req.Namespace, "name", req.Name)
+			}
+			return log
+		}).
 		Watches(
 			&corev1.Namespace{},
 			// We will enqueue policies with selectors that match the namespace

--- a/pkg/nftables/cleanup.go
+++ b/pkg/nftables/cleanup.go
@@ -137,6 +137,10 @@ func cleanUp(ctx context.Context, nft knftables.Interface, policyName string, po
 		}
 	}
 
+	if logger.V(1).Enabled() {
+		logger.V(1).Info("Applying nftables cleanup transaction", "transaction", tx.String())
+	}
+
 	err = nft.Run(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to run transaction: %w", err)

--- a/pkg/nftables/enforce.go
+++ b/pkg/nftables/enforce.go
@@ -109,6 +109,10 @@ func (n *NFTables) enforcePolicy(ctx context.Context, pod *corev1.Pod, interface
 		logger.Info("Egress rules applied")
 	}
 
+	if logger.V(1).Enabled() {
+		logger.V(1).Info("Applying nftables transaction", "transaction", tx.String())
+	}
+
 	err = nft.Run(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to run transaction: %w", err)
@@ -159,6 +163,10 @@ func ensureBasicStructure(ctx context.Context, nft knftables.Interface, commonRu
 
 	// Create common rules
 	createCommonRules(tx, commonRules, logger)
+
+	if logger.V(1).Enabled() {
+		logger.V(1).Info("Applying nftables basic structure transaction", "transaction", tx.String())
+	}
 
 	err = nft.Run(ctx, tx)
 	if err != nil {


### PR DESCRIPTION
- Log nft rules before applying
- Remove logs redundancy 

Logs change sample:
```
2026-04-28T06:29:48Z	DEBUG	Adding custom rule to common ingress chain	{"controller": "multinetworkpolicy", "controllerGroup": "k8s.cni.cncf.io", "controllerKind": "MultiNetworkPolicy", "MultiNetworkPolicy": {"name":"deny-ingress-pod-abzdgn","namespace":"e2e-test-multinetpol-e2e-mvvj4"}, "namespace": "e2e-test-multinetpol-e2e-mvvj4", "name": "deny-ingress-pod-abzdgn", "reconcileID": "0aeaafb2-5336-4e97-9a09-5bba924049a5", "namespace": "e2e-test-multinetpol-e2e-mvvj4", "name": "deny-ingress-pod-abzdgn", "pod": "multinetpol-test-pod-7wzcx", "namespace": "e2e-test-multinetpol-e2e-mvvj4", "rule": "icmpv6 type nd-neighbor-advert accept"}
```
to
```
2026-04-29T16:12:31Z	DEBUG	Adding custom rule to common ingress chain	{"namespace": "test-simple-v6-ingress", "name": "test-multinetwork-policy-simple-1", "reconcileID": "2d4e1065-241c-4ebe-814a-25d68b06b218", "pod": "pod-server", "namespace": "test-simple-v6-ingress", "rule": "tcp dport 9999 accept"}
```