### PR TITLE
Add CI workflows to publish container images to GHCR

### DIFF
--- a/.github/workflows/image-push-main.yml
+++ b/.github/workflows/image-push-main.yml
@@ -1,0 +1,51 @@
+name: "Push images on merge to main"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  BUILD_PLATFORMS: linux/amd64,linux/arm64
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Build and push multi-networkpolicy-nftables
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          file: ./Dockerfile

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,0 +1,52 @@
+name: "Push images on release"
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  BUILD_PLATFORMS: linux/amd64,linux/arm64
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+
+      - name: Build and push multi-networkpolicy-nftables
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          file: ./Dockerfile


### PR DESCRIPTION
Build and push multi-arch images (linux/amd64, linux/arm64) to ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-nftables on pushes to the main branch (tagged latest + SHA) and on version tags (tagged with the version).

Fixes: https://github.com/k8snetworkplumbingwg/multi-networkpolicy-nftables/issues/53

See https://github.com/zeeke/multi-networkpolicy-nftables/pkgs/container/multi-networkpolicy-nftables
as an example

cc @vladonutu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated Docker image building and publishing workflows are now enabled for continuous deployment
  * Docker images are automatically built and pushed to GitHub Container Registry on every update to the main branch and on versioned releases
  * Multi-platform container support for Linux AMD64 and ARM64
  * Release builds are tagged with version information, with “latest” applied for release images
<!-- end of auto-generated comment: release notes by coderabbit.ai -->